### PR TITLE
Add multiple data at the same time in the cache

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -324,4 +324,17 @@ class Cache
 
         throw new BadMethodCallException("The $name method does not exist");
     }
+
+    /**
+     * @param array $data
+     * @return bool
+     */
+    public static function addMany(array $data) : bool
+    {
+        foreach ($data as $attributes => $value) {
+            static::add($attributes, $value);
+        }
+
+        return true;
+    }
 }

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -6,6 +6,13 @@ use \Bow\Cache\Cache;
 
 class CacheTest extends \PHPUnit\Framework\TestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        Cache::confirgure(__DIR__.'/data/cache/bow');
+    }
+
     public function testCreateCache()
     {
         Cache::confirgure(__DIR__.'/data/cache/bow');
@@ -114,5 +121,20 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $r1 = Cache::timeOf('age');
 
         $this->assertEquals(is_int($r1), true);
+    }
+
+    public function testCanAddManyDataAtTheSameTimeInTheCache()
+    {
+        $passes = Cache::addMany(['name' => 'Doe', 'first_name' => 'John']);
+
+        $this->assertEquals($passes, true);
+    }
+
+    public function testCanRetrieveMultipleCacheStored()
+    {
+        Cache::addMany(['name' => 'Doe', 'first_name' => 'John']);
+
+        $this->assertEquals(Cache::get('name'), 'Doe');
+        $this->assertEquals(Cache::get('first_name'), 'John');
     }
 }

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -13,10 +13,15 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         Cache::confirgure(__DIR__.'/data/cache/bow');
     }
 
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        Cache::clear();
+    }
+
     public function testCreateCache()
     {
-        Cache::confirgure(__DIR__.'/data/cache/bow');
-
         $r = Cache::add('name', 'Dakia');
 
         $this->assertEquals($r, true);
@@ -137,4 +142,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(Cache::get('name'), 'Doe');
         $this->assertEquals(Cache::get('first_name'), 'John');
     }
+
+    
+
 }


### PR DESCRIPTION
Hello team,

This pull request is a feature in the cache to allow us to add many data at the same time.
If you want 3 data in the cache at this moment, what you have to do is

```php
   Cache::add('name', 'Juvenal');
   Cache::add('age', '40');
   Cache::add('job', 'Software Engineer');
```

The feature I added, will allow us to have a short api like this
```php
   Cache::addMany(['name' => 'juvenal', 'age' => '40', 'job' => 'Software Engineer']);
```


