### PR TITLE
[cache] Fix bug of clearing cache

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -4,6 +4,9 @@ namespace Bow\Cache;
 
 use BadMethodCallException;
 use Bow\Support\Str;
+use DirectoryIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 class Cache
 {
@@ -302,10 +305,15 @@ class Cache
      */
     public static function clear()
     {
-        $glob = glob(static::$directory);
+        $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator(static::$directory),
+            RecursiveIteratorIterator::SELF_FIRST
+        );
 
-        foreach ($glob as $item) {
-            @unlink($item);
+        foreach($iterator as $file) {
+            if(! $file->isDir()) {
+               unlink($file->getRealPath());
+            }
         }
     }
 

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -13,12 +13,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         Cache::confirgure(__DIR__.'/data/cache/bow');
     }
 
-    public function tearDown()
-    {
-        parent::tearDown();
 
-        Cache::clear();
-    }
 
     public function testCreateCache()
     {
@@ -143,6 +138,16 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(Cache::get('first_name'), 'John');
     }
 
-    
+    public function testClearCache()
+    {
+        Cache::addMany(['name' => 'Doe', 'first_name' => 'John']);
 
+        $this->assertEquals(Cache::get('first_name'), 'John');
+        $this->assertEquals(Cache::get('name'), 'Doe');
+
+        Cache::clear();
+
+        $this->assertNull(Cache::get('name'));
+        $this->assertNull(Cache::get('first_name'));
+    }
 }


### PR DESCRIPTION
When I was exploring the cache tests.
I have noticed that there isn't a test for clear the cache.

I tried to write the tests of clearing a cache but this test failed.

So I changed the clear method which uses the RecursiveIteratorIterator in order to find cached file.

Can you try to reproduce or create a test for clear cache ?
I hope my PR won't break any feature.